### PR TITLE
Remove password hashing

### DIFF
--- a/login.php
+++ b/login.php
@@ -6,9 +6,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt = $mysqli->prepare("SELECT id, password, is_admin FROM users WHERE login = ?");
     $stmt->bind_param('s', $login);
     $stmt->execute();
-    $stmt->bind_result($id, $passHash, $isAdmin);
+    $stmt->bind_result($id, $storedPassword, $isAdmin);
     if ($stmt->fetch()) {
-        if (password_verify($password, $passHash)) {
+        if ($password === $storedPassword) {
             $_SESSION['user_id'] = $id;
             $_SESSION['is_admin'] = ($isAdmin == 1);
             header('Location: dashboard.php');

--- a/register.php
+++ b/register.php
@@ -13,8 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (mb_strlen($password) < 6) $errors[] = 'Пароль должен быть не менее 6 символов';
     if (empty($errors)) {
         $stmt = $mysqli->prepare("INSERT INTO users (fio, phone, email, login, password, is_admin) VALUES (?, ?, ?, ?, ?, 0)");
-        $passwordHash = password_hash($password, PASSWORD_DEFAULT);
-        $stmt->bind_param('sssss', $fio, $phone, $email, $login, $passwordHash);
+        $stmt->bind_param('sssss', $fio, $phone, $email, $login, $password);
         if ($stmt->execute()) header('Location: login.php');
         else $errors[] = 'Логин уже существует';
     }

--- a/schema.sql
+++ b/schema.sql
@@ -27,4 +27,4 @@ CREATE TABLE requests (
 
 INSERT INTO users (fio, phone, email, login, password, is_admin)
 VALUES ('Администратор', '+7(999)-999-99-99', 'admin@gruzovozoff.ru', 'adminadmin',
-'$2y$10$RMsyX3K6SRc6vlHzvDLp8ewBnIGEdCSyhk/s5qk4LeJ4XIMkpqeeC', 1);
+'adminadmin', 1);


### PR DESCRIPTION
## Summary
- store plain passwords during registration
- compare plain passwords on login
- update initial admin password in schema

## Testing
- `php -l register.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685468c3280c833384062442e3c1565e

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying user authentication by removing password hashing during user registration and login, allowing plaintext passwords to be stored and compared directly.

### Detailed summary
- In `schema.sql`, the default password for the admin user is changed to plaintext.
- In `login.php`, the password verification method is changed from `password_verify` to a direct comparison of plaintext passwords.
- In `register.php`, the password is now stored as plaintext instead of a hashed value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->