### PR TITLE
Fix undefined feedback key warning

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -34,7 +34,7 @@ $result = $mysqli->query("SELECT r.*, u.fio FROM requests r JOIN users u ON r.us
             <td><?= $row['from_address'] ?></td>
             <td><?= $row['to_address'] ?></td>
             <td><span class="<?= $badge ?>"><?= $statusMap[$row['status']] ?? $row['status'] ?></span></td>
-            <td><?= htmlspecialchars($row['feedback']) ?></td>
+            <td><?= htmlspecialchars($row['feedback'] ?? '') ?></td>
             <td>
                 <a class="btn btn-sm btn-info mb-1" href="?id=<?= $row['id'] ?>&set_status=new">Новая</a>
                 <a class="btn btn-sm btn-success mb-1" href="?id=<?= $row['id'] ?>&set_status=in_progress">В работе</a>

--- a/requests.php
+++ b/requests.php
@@ -28,7 +28,7 @@ $result = $mysqli->query("SELECT * FROM requests WHERE user_id = $user_id ORDER 
             <td><?= $row['to_address'] ?></td>
             <td><?= $statusMap[$row['status']] ?? $row['status'] ?></td>
             <td>
-                <?php if ($row['feedback']): ?>
+                <?php if (!empty($row['feedback'])): ?>
                     <?= htmlspecialchars($row['feedback']) ?>
                 <?php else: ?>
                     <form method="POST" class="d-flex">


### PR DESCRIPTION
## Summary
- guard against missing feedback column in user and admin views

## Testing
- `php -l requests.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68547a4609d48333917c4177e5d96a9e

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `feedback` field in the `requests.php` and `admin.php` files by ensuring that it checks for non-empty values and provides a default empty string when necessary.

### Detailed summary
- In `requests.php`, changed the condition from checking if `feedback` is set to checking if it is not empty.
- In `admin.php`, modified the `feedback` output to use the null coalescing operator, providing an empty string as a default value if `feedback` is not set.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->