### PR TITLE
Add feedback display page

### DIFF
--- a/feedbacks.php
+++ b/feedbacks.php
@@ -1,0 +1,18 @@
+<?php require 'db.php'; require 'navbar.php';
+$result = $mysqli->query("SELECT r.feedback, u.fio FROM requests r JOIN users u ON r.user_id = u.id WHERE r.feedback IS NOT NULL AND r.feedback <> '' ORDER BY r.id DESC");
+?>
+<div class="container">
+    <h2>Отзывы клиентов</h2>
+    <?php if ($result->num_rows > 0): ?>
+        <?php while ($row = $result->fetch_assoc()): ?>
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title"><?= htmlspecialchars($row['fio']) ?></h5>
+                    <p class="card-text"><?= nl2br(htmlspecialchars($row['feedback'])) ?></p>
+                </div>
+            </div>
+        <?php endwhile; ?>
+    <?php else: ?>
+        <p>Пока нет отзывов.</p>
+    <?php endif; ?>
+</div>

--- a/navbar.php
+++ b/navbar.php
@@ -13,6 +13,7 @@ if (session_status() === PHP_SESSION_NONE) {
     </button>
     <div class="collapse navbar-collapse" id="navmenu">
       <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="feedbacks.php">Отзывы</a></li>
         <?php if(isset($_SESSION['user_id'])): ?>
           <li class="nav-item"><a class="nav-link" href="new_request.php">Создать заявку</a></li>
           <li class="nav-item"><a class="nav-link" href="requests.php">Мои заявки</a></li>


### PR DESCRIPTION
## Summary
- add page to list saved feedback
- link new page from navigation

## Testing
- `php -l feedbacks.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68547d168d3c8333b3987cae6b27766b

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new section for customer feedback on the `feedbacks.php` page and updates the `navbar.php` to include a link to this new section.

### Detailed summary
- Added a new `<li>` element in `navbar.php` for "Отзывы" (Feedback).
- Created a database query in `feedbacks.php` to fetch feedback from users.
- Displayed feedback in a card format, showing user name and feedback text.
- Added a message for when there are no feedback entries available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->