### PR TITLE
Fix feedback display error

### DIFF
--- a/feedbacks.php
+++ b/feedbacks.php
@@ -1,9 +1,15 @@
 <?php require 'db.php'; require 'navbar.php';
 $result = $mysqli->query("SELECT r.feedback, u.fio FROM requests r JOIN users u ON r.user_id = u.id WHERE r.feedback IS NOT NULL AND r.feedback <> '' ORDER BY r.id DESC");
+$hasRows = false;
+if ($result === false) {
+    error_log('DB query failed in feedbacks.php: ' . $mysqli->error);
+} else {
+    $hasRows = $result->num_rows > 0;
+}
 ?>
 <div class="container">
     <h2>Отзывы клиентов</h2>
-    <?php if ($result->num_rows > 0): ?>
+    <?php if ($hasRows): ?>
         <?php while ($row = $result->fetch_assoc()): ?>
             <div class="card">
                 <div class="card-body">
@@ -12,7 +18,9 @@ $result = $mysqli->query("SELECT r.feedback, u.fio FROM requests r JOIN users u 
                 </div>
             </div>
         <?php endwhile; ?>
-    <?php else: ?>
+    <?php elseif ($result !== false): ?>
         <p>Пока нет отзывов.</p>
+    <?php else: ?>
+        <p>Ошибка при загрузке отзывов.</p>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
## Summary
- handle DB failures in the feedbacks page

## Testing
- `php -l feedbacks.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685480bc4dc88333a8acfefc6bd891a5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling and code readability in the `feedbacks.php` file by introducing a variable to check for rows in the database query result and adjusting the conditional logic accordingly.

### Detailed summary
- Introduced the variable `$hasRows` to check if the query result has rows.
- Added error logging for failed database queries.
- Updated the conditional check from `$result->num_rows > 0` to use `$hasRows`.
- Modified the else clause to handle database errors more gracefully.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->