### PR TITLE
Add service reviews

### DIFF
--- a/feedbacks.php
+++ b/feedbacks.php
@@ -1,5 +1,29 @@
-<?php require 'db.php'; require 'navbar.php';
-$result = $mysqli->query("SELECT r.feedback, u.fio FROM requests r JOIN users u ON r.user_id = u.id WHERE r.feedback IS NOT NULL AND r.feedback <> '' ORDER BY r.id DESC");
+<?php
+require 'db.php';
+require 'navbar.php';
+
+// Handle new review submission
+if (isset($_SESSION['user_id']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $rating = (int)($_POST['rating'] ?? 0);
+    $comment = trim($_POST['comment'] ?? '');
+    if ($rating >= 1 && $rating <= 5 && $comment !== '') {
+        $stmt = $mysqli->prepare(
+            "INSERT INTO service_reviews (user_id, rating, comment) VALUES (?, ?, ?)"
+        );
+        if ($stmt) {
+            $stmt->bind_param('iis', $_SESSION['user_id'], $rating, $comment);
+            $stmt->execute();
+            $stmt->close();
+        } else {
+            error_log('DB prepare failed in feedbacks.php: ' . $mysqli->error);
+        }
+    }
+}
+
+$result = $mysqli->query(
+    "SELECT s.rating, s.comment, s.created_at, u.fio " .
+    "FROM service_reviews s JOIN users u ON s.user_id = u.id ORDER BY s.id DESC"
+);
 $hasRows = false;
 if ($result === false) {
     error_log('DB query failed in feedbacks.php: ' . $mysqli->error);
@@ -9,12 +33,35 @@ if ($result === false) {
 ?>
 <div class="container">
     <h2>Отзывы клиентов</h2>
+    <?php if(isset($_SESSION['user_id'])): ?>
+        <form method="POST" class="mb-4">
+            <div class="mb-2">
+                <label class="form-label">Оценка</label>
+                <select name="rating" class="form-select" required>
+                    <option value="">Выберите</option>
+                    <?php for($i=5; $i>=1; $i--): ?>
+                        <option value="<?= $i ?>"><?= $i ?></option>
+                    <?php endfor; ?>
+                </select>
+            </div>
+            <div class="mb-2">
+                <label class="form-label">Комментарий</label>
+                <textarea name="comment" class="form-control" required></textarea>
+            </div>
+            <button class="btn btn-primary" type="submit">Оставить отзыв</button>
+        </form>
+    <?php endif; ?>
+
     <?php if ($hasRows): ?>
         <?php while ($row = $result->fetch_assoc()): ?>
-            <div class="card">
+            <div class="card mb-3">
                 <div class="card-body">
-                    <h5 class="card-title"><?= htmlspecialchars($row['fio']) ?></h5>
-                    <p class="card-text"><?= nl2br(htmlspecialchars($row['feedback'])) ?></p>
+                    <h5 class="card-title">
+                        <?= htmlspecialchars($row['fio']) ?>
+                        <small class="text-muted"><?= htmlspecialchars($row['created_at']) ?></small>
+                    </h5>
+                    <p class="card-text mb-1">Оценка: <?= (int)$row['rating'] ?>/5</p>
+                    <p class="card-text"><?= nl2br(htmlspecialchars($row['comment'])) ?></p>
                 </div>
             </div>
         <?php endwhile; ?>

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,15 @@ CREATE TABLE requests (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+CREATE TABLE service_reviews (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    rating TINYINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    comment TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 INSERT INTO users (fio, phone, email, login, password, is_admin)
 VALUES ('Администратор', '+7(999)-999-99-99', 'admin@gruzovozoff.ru', 'admin',
 'gruzok2024', 1);


### PR DESCRIPTION
## Summary
- create `service_reviews` table in schema
- allow users to post service reviews with rating
- show service reviews on feedback page

## Testing
- `php -l feedbacks.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685489a3b8788333bc66f4728bf448af

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `service_reviews` table to store user reviews, along with functionality in `feedbacks.php` for users to submit their ratings and comments. It also updates the display of existing reviews to show ratings and comments clearly.

### Detailed summary
- Added a new table `service_reviews` in `schema.sql` for storing user reviews.
- Implemented review submission handling in `feedbacks.php` with form for rating and comment.
- Modified the query in `feedbacks.php` to retrieve ratings and comments from `service_reviews`.
- Updated the display of reviews to include user ratings and timestamps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->