### PR TITLE
Fix review and request saving issues

### DIFF
--- a/feedbacks.php
+++ b/feedbacks.php
@@ -12,7 +12,9 @@ if (isset($_SESSION['user_id']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
         );
         if ($stmt) {
             $stmt->bind_param('iis', $_SESSION['user_id'], $rating, $comment);
-            $stmt->execute();
+            if (!$stmt->execute()) {
+                error_log('DB execute failed in feedbacks.php: ' . $stmt->error);
+            }
             $stmt->close();
         } else {
             error_log('DB prepare failed in feedbacks.php: ' . $mysqli->error);

--- a/new_request.php
+++ b/new_request.php
@@ -11,11 +11,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $from = $_POST['from_address'] ?? '';
     $to = $_POST['to_address'] ?? '';
 
-    $stmt = $mysqli->prepare("INSERT INTO requests (user_id, request_date, request_time, weight, dimensions, cargo_type, from_address, to_address)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
-    $stmt->bind_param('issdssss', $_SESSION['user_id'], $req_date, $req_time, $weight, $dims, $type, $from, $to);
-    $stmt->execute();
-    $msg = 'Заявка успешно создана!';
+    $stmt = $mysqli->prepare(
+        "INSERT INTO requests (user_id, request_date, request_time, weight, dimensions, cargo_type, from_address, to_address)" .
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+    if ($stmt) {
+        $weight = (float) $weight;
+        $stmt->bind_param('issdssss', $_SESSION['user_id'], $req_date, $req_time, $weight, $dims, $type, $from, $to);
+        if ($stmt->execute()) {
+            $msg = 'Заявка успешно создана!';
+        } else {
+            $msg = 'Ошибка при сохранении заявки: ' . $stmt->error;
+        }
+        $stmt->close();
+    } else {
+        $msg = 'Ошибка подготовки запроса: ' . $mysqli->error;
+    }
 }
 ?>
 <div class="container">


### PR DESCRIPTION
## Summary
- add error handling to review saving
- add error handling when creating requests

## Testing
- `php -l feedbacks.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68548c02dc2c8333b09a0fb04d6d6334

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `feedbacks.php` and `new_request.php` files. It adds checks for the success of database operations and logs errors when they fail.

### Detailed summary
- In `feedbacks.php`, added error logging for failed `execute()` calls.
- In `new_request.php`, restructured the query preparation and execution.
- Added error handling for `prepare()` and `execute()` in `new_request.php`, logging messages for failures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->