### PR TITLE
Remove Bootstrap dependency

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,144 @@
-body { padding-top: 60px; }
-.navbar-brand { font-weight: bold; }
-.card { margin-bottom: 20px; }
+body {
+    margin: 0;
+    padding-top: 60px;
+    font-family: Arial, sans-serif;
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 15px;
+}
+
+.navbar {
+    background: #0d6efd;
+    color: #fff;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+}
+.navbar .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px;
+}
+.navbar a {
+    color: #fff;
+    text-decoration: none;
+}
+.navbar a:hover {
+    text-decoration: underline;
+}
+.nav-link {
+    color: inherit;
+}
+.navbar-nav {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+.navbar-nav li {
+    margin-left: 15px;
+}
+.nav-item { list-style: none; }
+.navbar-brand {
+    font-weight: bold;
+}
+
+.btn {
+    display: inline-block;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+}
+.btn-primary {
+    background: #0d6efd;
+    color: #fff;
+}
+.btn-success { background: #198754; color: #fff; }
+.btn-danger  { background: #dc3545; color: #fff; }
+.btn-info    { background: #0dcaf0; color: #000; }
+.btn-sm { padding: 2px 6px; font-size: 0.875rem; }
+.w-100 { width: 100%; }
+
+.form-control, .form-select {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+.form-label {
+    margin-bottom: 0.25rem;
+    display: block;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.table th,
+.table td {
+    border: 1px solid #dee2e6;
+    padding: 8px;
+}
+.table-striped tr:nth-child(even) {
+    background: #f2f2f2;
+}
+.table-primary th {
+    background: #cfe2ff;
+}
+
+.card {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+}
+.card-body { padding: 15px; }
+.card-title { margin: 0 0 10px; font-size: 1.25rem; }
+.card-text { margin-bottom: 10px; }
+
+.alert {
+    padding: 10px;
+    border-radius: 4px;
+}
+.alert-success { background: #d1e7dd; color: #0f5132; }
+.text-danger { color: #dc3545; }
+.text-muted { color: #6c757d; }
+
+.badge {
+    display: inline-block;
+    padding: 0.35em 0.65em;
+    border-radius: 0.25rem;
+    color: #fff;
+    font-size: 0.75rem;
+}
+.bg-info    { background: #0dcaf0; }
+.bg-success { background: #198754; }
+.bg-danger  { background: #dc3545; }
+
+.list-group { list-style: none; padding: 0; margin: 0; }
+.list-group-item {
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin-bottom: -1px;
+}
+
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 1rem; }
+.mt-4 { margin-top: 1.5rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 1rem; }
+.mb-4 { margin-bottom: 1.5rem; }
+.me-2 { margin-right: 0.5rem; }
+.p-4 { padding: 1.5rem; }
+.lead { font-size: 1.25rem; font-weight: 300; }
+.d-flex { display: flex; }
+.ms-auto { margin-left: auto; }

--- a/navbar.php
+++ b/navbar.php
@@ -3,16 +3,11 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 ?>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel='stylesheet' href='assets/css/style.css'>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
+<nav class="navbar">
   <div class="container">
     <a class="navbar-brand" href="dashboard.php">Грузовозофф</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navmenu">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navmenu">
-      <ul class="navbar-nav ms-auto">
+    <ul class="navbar-nav ms-auto">
         <li class="nav-item"><a class="nav-link" href="feedbacks.php">Отзывы</a></li>
         <?php if(isset($_SESSION['user_id'])): ?>
           <li class="nav-item"><a class="nav-link" href="new_request.php">Создать заявку</a></li>
@@ -26,9 +21,6 @@ if (session_status() === PHP_SESSION_NONE) {
           <li class="nav-item"><a class="nav-link" href="register.php">Регистрация</a></li>
         <?php endif; ?>
       </ul>
-    </div>
   </div>
 </nav>
-<br><br><br>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src='assets/js/script.js'></script>


### PR DESCRIPTION
## Summary
- drop Bootstrap assets from navbar
- recreate styling with custom CSS

## Testing
- `php -l navbar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685524208cc88333b5ddbb93d472125f

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `navbar.php` file by removing Bootstrap's CDN links and restructuring the navigation bar. It also introduces extensive CSS styles in `style.css` for a custom design, enhancing the overall layout and appearance of the navbar and other components.

### Detailed summary
- Removed Bootstrap CDN links from `navbar.php`.
- Simplified the `<nav>` structure in `navbar.php`.
- Added custom CSS styles in `style.css` for:
  - General body styling and layout.
  - Navbar appearance and behavior.
  - Button styles and hover effects.
  - Form and table styling.
  - Utility classes for margins and paddings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->